### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -21,7 +21,7 @@ class action_plugin_facebook extends DokuWiki_Action_Plugin {
         return confToHash(dirname(__FILE__).'/plugin.info.txt');
     }
 
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
 
        $controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this, 'handle_tpl_metaheader_output');
 

--- a/syntax.php
+++ b/syntax.php
@@ -38,7 +38,7 @@ class syntax_plugin_facebook extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('{{fbfanbox>[0-9]+.*?}}',$mode,'plugin_facebook');
     }
 
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 
         $data = array(
             'type'    => 'fanbox',
@@ -83,7 +83,7 @@ class syntax_plugin_facebook extends DokuWiki_Syntax_Plugin {
         return $data;
     }
 
-    function render($mode, &$R, $data) {
+    function render($mode, Doku_Renderer $R, $data) {
         if($mode != 'xhtml') return false;
 
         if($data['align'] == 'center'){


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
